### PR TITLE
There are no more than 52 weeks in a year!

### DIFF
--- a/lib/cohort_me.rb
+++ b/lib/cohort_me.rb
@@ -73,7 +73,7 @@ module CohortMe
   def self.convert_to_cohort_date(datetime, interval)
     if interval == "weeks"
       year_and_week = datetime.strftime("%Y-%U").split("-")
-      return Date.commercial(year_and_week[0].to_i, year_and_week[1].to_i + 1)
+      return Date.commercial(year_and_week[0].to_i, year_and_week[1].to_i == 52 ? 52 : year_and_week[1].to_i + 1)
 
     elsif interval == "days"
       return Date.parse(datetime.strftime("%Y-%m-%d"))


### PR DESCRIPTION
Found an edge case - where it would try to calculate week 53 which doesn't exist throwing an invalid date error.

```
[2] pry(CohortMe)> Date.commercial(year_and_week[0].to_i, year_and_week[1].to_i + 1)
ArgumentError: invalid date
from (pry):7:in `commercial'
[3] pry(CohortMe)> year_and_week
=> ["2012", "52"]
```

This stops it from blowing up. But I'm not 100% sure what the correct fix for this is though? Is the correct solution for it to go into the first day of the next year? ie. ['2013', '01']
