### PR TITLE
Change default for activity_user_id if unspecified

### DIFF
--- a/lib/cohort_me.rb
+++ b/lib/cohort_me.rb
@@ -13,7 +13,7 @@ module CohortMe
 
     activity_class = options[:activity_class] || activation_class
     activity_table_name = ActiveModel::Naming.plural(activity_class)
-    activity_user_id = options[:activity_user_id] || "user_id"
+    activity_user_id = options[:activity_user_id] || activation_user_id
 
     period_values = %w[weeks days months]
 


### PR DESCRIPTION
Use the activation_user_id as default for activity_user_id. This prevents an error when the activation_user_id is specified to be something different but the activity class is still the activation class by default.
